### PR TITLE
vhp find publicvulns: GitAPI Fix

### DIFF
--- a/lib/vhp/commits/vuln_files.rb
+++ b/lib/vhp/commits/vuln_files.rb
@@ -37,8 +37,7 @@ module VHP
           end
         end
       end
-      # FIXME Update to new GitAPI
-      # result = GitLog.new(@options[:repo]).get_files_from_shas(fixes)
+      result = GitAPI.new(@options[:repo]).get_files_from_shas(fixes)
       puts "Writing output file #{@options[:output]}"
       CSV.open(@options[:output], 'w+') do |csv|
         csv << [ 'filepath' ]


### PR DESCRIPTION
It looks like there was a line of code connected to publicvulns that wasn't updated when another part of the program was changed. I updated the line of code to use the other part of the system.